### PR TITLE
Remove skip-pkg-cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,5 +27,4 @@ jobs:
         uses: golangci/golangci-lint-action@v5
         with:
           version: ${{ steps.golangci-lint-version.outputs.v }}
-          skip-pkg-cache: true
           args: --timeout=2m


### PR DESCRIPTION
### Description

Remove redundant option in `lint.yml`.